### PR TITLE
profiler: fix deprecation notices

### DIFF
--- a/system/libraries/Profiler.php
+++ b/system/libraries/Profiler.php
@@ -53,6 +53,7 @@ defined('BASEPATH') OR exit('No direct script access allowed');
  * @author		EllisLab Dev Team
  * @link		https://codeigniter.com/userguide3/general/profiling.html
  */
+#[AllowDynamicProperties]
 class CI_Profiler {
 
 	/**


### PR DESCRIPTION
To test, use `$this->output->enable_profiler(true);`

Fixes around 10 deprecation notices emitted when the profiler is turned on. Example:

```
Message: Creation of dynamic property CI_Profiler::$_compile_benchmarks is deprecated

Filename: libraries/Profiler.php

Line Number: 109
```