### PR TITLE
Fix warning and ignored TTL in Redis cache driver

### DIFF
--- a/system/libraries/Cache/drivers/Cache_redis.php
+++ b/system/libraries/Cache/drivers/Cache_redis.php
@@ -163,7 +163,7 @@ class CI_Cache_redis extends CI_Driver
 	{
 		$data = $this->_redis->hMGet($key, array('__ci_type', '__ci_value'));
 
-		if ($value !== FALSE && $this->_redis->sIsMember('_ci_redis_serialized', $key))
+		if ($data === FALSE || $this->_redis->sIsMember('_ci_redis_serialized', $key))
 		{
 			return FALSE;
 		}
@@ -223,6 +223,7 @@ class CI_Cache_redis extends CI_Driver
 		}
 		else
 		{
+			$this->_redis->expireAt($id, time() + $ttl);
 			$this->_redis->{static::$_sRemove_name}('_ci_redis_serialized', $id);
 		}
 


### PR DESCRIPTION
Resolves #10 