### PR TITLE
mimes: add support for webp image type

### DIFF
--- a/application/config/mimes.php
+++ b/application/config/mimes.php
@@ -182,5 +182,6 @@ return array(
 	'odt'	=>	'application/vnd.oasis.opendocument.text',
 	'odm'	=>	'application/vnd.oasis.opendocument.text-master',
 	'ott'	=>	'application/vnd.oasis.opendocument.text-template',
-	'oth'	=>	'application/vnd.oasis.opendocument.text-web'
+	'oth'	=>	'application/vnd.oasis.opendocument.text-web',
+	'webp'  =>	'image/webp'
 );


### PR DESCRIPTION
Why
- the .webp image type has become common on the internet

What
- modify application/config/mimes.php to include `'webp'  =>	'image/webp'`