### PR TITLE
Fix deprecation notice for passing null to preg_replace

### DIFF
--- a/system/core/Common.php
+++ b/system/core/Common.php
@@ -727,7 +727,7 @@ if ( ! function_exists('remove_invisible_characters'))
 
 		do
 		{
-			$str = preg_replace($non_displayables, '', $str, -1, $count);
+			$str = preg_replace($non_displayables, '', (string)$str, -1, $count);
 		}
 		while ($count);
 


### PR DESCRIPTION
We've been seeing the following warning in our logs:
```
Severity: 8192 --> preg_replace(): Passing null to parameter #3 ($subject) of type array|string is deprecated /var/www/somoplatform/current/system/core/Common.php 730
```

This PR fixes the problem.  For reference, the root cause is calling `$this->security->xss_clean()` passing either a `null` or an array that has one or more `null` values.