### PR TITLE
Fix Redis session driver returning success on failed connection

### DIFF
--- a/system/libraries/Session/drivers/Session_redis_driver.php
+++ b/system/libraries/Session/drivers/Session_redis_driver.php
@@ -217,9 +217,7 @@ class CI_Session_redis_driver extends CI_Session_driver implements CI_Session_dr
 		}
 		else
 		{
-			$this->_redis = $redis;
-			$this->php5_validate_id();
-			return $this->_success;
+			log_message('error', 'Session: Unable to connect to Redis with the configured settings.');
 		}
 
 		return $this->_failure;


### PR DESCRIPTION
The open() method in Session_redis_driver returns $this->_success even when Redis::connect() fails. The else branch (lines 218-223) sets $this->_redis and returns success for a connection that didn't actually connect.

This causes PHP's session_start() to believe the handler is ready, but subsequent read() calls fail, producing:

session_start(): Failed to read session data: user (path: /var/lib/php/sessions)
This is a regression from the original CodeIgniter 3.1.13, where the open() method used a flat if/elseif/else chain that correctly fell through to return $this->_failure when the connection failed. The restructuring into the $connected variable pattern introduced this bug.

The fix changes the failed-connection else branch to log an error and fall through to return $this->_failure instead of incorrectly returning $this->_success.