### PR TITLE
Restore deprecated functions that were removed in 3.2.0-dev (for backward compatibility).

### DIFF
--- a/application/config/smileys.php
+++ b/application/config/smileys.php
@@ -1,0 +1,64 @@
+<?php
+defined('BASEPATH') OR exit('No direct script access allowed');
+
+/*
+| -------------------------------------------------------------------
+| SMILEYS
+| -------------------------------------------------------------------
+| This file contains an array of smileys for use with the emoticon helper.
+| Individual images can be used to replace multiple smileys.  For example:
+| :-) and :) use the same image replacement.
+|
+| Please see user guide for more info:
+| https://codeigniter.com/user_guide/helpers/smiley_helper.html
+|
+*/
+$smileys = array(
+
+//	smiley			image name						width	height	alt
+
+	':-)'			=>	array('grin.gif',			'19',	'19',	'grin'),
+	':lol:'			=>	array('lol.gif',			'19',	'19',	'LOL'),
+	':cheese:'		=>	array('cheese.gif',			'19',	'19',	'cheese'),
+	':)'			=>	array('smile.gif',			'19',	'19',	'smile'),
+	';-)'			=>	array('wink.gif',			'19',	'19',	'wink'),
+	';)'			=>	array('wink.gif',			'19',	'19',	'wink'),
+	':smirk:'		=>	array('smirk.gif',			'19',	'19',	'smirk'),
+	':roll:'		=>	array('rolleyes.gif',		'19',	'19',	'rolleyes'),
+	':-S'			=>	array('confused.gif',		'19',	'19',	'confused'),
+	':wow:'			=>	array('surprise.gif',		'19',	'19',	'surprised'),
+	':bug:'			=>	array('bigsurprise.gif',	'19',	'19',	'big surprise'),
+	':-P'			=>	array('tongue_laugh.gif',	'19',	'19',	'tongue laugh'),
+	'%-P'			=>	array('tongue_rolleye.gif',	'19',	'19',	'tongue rolleye'),
+	';-P'			=>	array('tongue_wink.gif',	'19',	'19',	'tongue wink'),
+	':P'			=>	array('raspberry.gif',		'19',	'19',	'raspberry'),
+	':blank:'		=>	array('blank.gif',			'19',	'19',	'blank stare'),
+	':long:'		=>	array('longface.gif',		'19',	'19',	'long face'),
+	':ohh:'			=>	array('ohh.gif',			'19',	'19',	'ohh'),
+	':grrr:'		=>	array('grrr.gif',			'19',	'19',	'grrr'),
+	':gulp:'		=>	array('gulp.gif',			'19',	'19',	'gulp'),
+	'8-/'			=>	array('ohoh.gif',			'19',	'19',	'oh oh'),
+	':down:'		=>	array('downer.gif',			'19',	'19',	'downer'),
+	':red:'			=>	array('embarrassed.gif',	'19',	'19',	'red face'),
+	':sick:'		=>	array('sick.gif',			'19',	'19',	'sick'),
+	':shut:'		=>	array('shuteye.gif',		'19',	'19',	'shut eye'),
+	':-/'			=>	array('hmm.gif',			'19',	'19',	'hmmm'),
+	'>:('			=>	array('mad.gif',			'19',	'19',	'mad'),
+	':mad:'			=>	array('mad.gif',			'19',	'19',	'mad'),
+	'>:-('			=>	array('angry.gif',			'19',	'19',	'angry'),
+	':angry:'		=>	array('angry.gif',			'19',	'19',	'angry'),
+	':zip:'			=>	array('zip.gif',			'19',	'19',	'zipper'),
+	':kiss:'		=>	array('kiss.gif',			'19',	'19',	'kiss'),
+	':ahhh:'		=>	array('shock.gif',			'19',	'19',	'shock'),
+	':coolsmile:'	=>	array('shade_smile.gif',	'19',	'19',	'cool smile'),
+	':coolsmirk:'	=>	array('shade_smirk.gif',	'19',	'19',	'cool smirk'),
+	':coolgrin:'	=>	array('shade_grin.gif',		'19',	'19',	'cool grin'),
+	':coolhmm:'		=>	array('shade_hmm.gif',		'19',	'19',	'cool hmm'),
+	':coolmad:'		=>	array('shade_mad.gif',		'19',	'19',	'cool mad'),
+	':coolcheese:'	=>	array('shade_cheese.gif',	'19',	'19',	'cool cheese'),
+	':vampire:'		=>	array('vampire.gif',		'19',	'19',	'vampire'),
+	':snake:'		=>	array('snake.gif',			'19',	'19',	'snake'),
+	':exclaim:'		=>	array('exclaim.gif',		'19',	'19',	'exclaim'),
+	':question:'	=>	array('question.gif',		'19',	'19',	'question')
+
+);

--- a/readme.rst
+++ b/readme.rst
@@ -93,17 +93,9 @@ If you prefer the traditional approach of replacing the system directory:
 
 **Upgrading from Original CI3**
 
-⚠️ **Important:** This fork is based on the unreleased CodeIgniter 3.2.0-dev version, not the stable 3.1.13. If you're upgrading from CI 3.1.x, please read the upgrade guide for any changes that may affect your application.
+This fork is based on the unreleased CodeIgniter 3.2.0-dev. For most
+applications the upgrade is straightforward: install via Composer,
+update your `$system_path`, and review the upgrade guide.
 
-**Please review the upgrade guide:** `upgrade_320.rst <user_guide_src/source/installation/upgrade_320.rst>`_
-
-Note: The upgrade guide has been updated to reflect functionality we've restored for backward compatibility (Cart library, Email helper, etc.).
-
-Steps to upgrade:
-
-1. Review the upgrade guide for breaking changes between 3.1.x and 3.2.0
-2. Install via Composer as shown above
-3. Update the `$system_path` in your `index.php`
-4. Apply any necessary changes from the upgrade guide to your application
-5. Your existing `application/` directory remains mostly unchanged (except for items noted in the upgrade guide)
-6. Test thoroughly with your PHP version (especially if using PHP 8.2+)
+The upgrade guide covers both 3.1.x and 3.2-dev users:
+`upgrade_320.rst <user_guide_src/source/installation/upgrade_320.rst>`_

--- a/system/core/Config.php
+++ b/system/core/Config.php
@@ -326,6 +326,20 @@ class CI_Config {
 	// -------------------------------------------------------------
 
 	/**
+	 * System URL
+	 *
+	 * @deprecated	3.0.0
+	 * @return	string
+	 */
+	public function system_url()
+	{
+		$x = explode('/', preg_replace('|/*(.+?)/*$|', '\\1', BASEPATH));
+		return $this->slash_item('base_url').end($x).'/';
+	}
+
+	// -------------------------------------------------------------
+
+	/**
 	 * Build URI string
 	 *
 	 * @used-by	CI_Config::site_url()

--- a/system/core/Input.php
+++ b/system/core/Input.php
@@ -663,6 +663,22 @@ class CI_Input {
 	// --------------------------------------------------------------------
 
 	/**
+	 * Is CLI request?
+	 *
+	 * Test to see if a request was made from the command line.
+	 *
+	 * @deprecated	3.0.0	Use is_cli() instead
+	 * @see		is_cli()
+	 * @return	bool
+	 */
+	public function is_cli_request()
+	{
+		return is_cli();
+	}
+
+	// --------------------------------------------------------------------
+
+	/**
 	 * Get Request Method
 	 *
 	 * Return the request method

--- a/system/database/DB_forge.php
+++ b/system/database/DB_forge.php
@@ -561,13 +561,18 @@ abstract class CI_DB_forge {
 	 * @param	array	$field	Column definition
 	 * @return	bool
 	 */
-	public function add_column($table, $field)
+	public function add_column($table, $field, $_after = NULL)
 	{
 		// Work-around for literal column definitions
 		is_array($field) OR $field = array($field);
 
 		foreach (array_keys($field) as $k)
 		{
+			if ($_after !== NULL && is_array($field[$k]) && ! isset($field[$k]['after']))
+			{
+				$field[$k]['after'] = $_after;
+			}
+
 			$this->add_field(array($k => $field[$k]));
 		}
 

--- a/system/helpers/date_helper.php
+++ b/system/helpers/date_helper.php
@@ -123,6 +123,42 @@ if ( ! function_exists('mdate'))
 
 // ------------------------------------------------------------------------
 
+if ( ! function_exists('standard_date'))
+{
+	/**
+	 * Standard Date
+	 *
+	 * Returns a date formatted according to the submitted standard.
+	 *
+	 * As of PHP 5.2, the DateTime extension provides constants that
+	 * serve for the exact same purpose and are used internally by
+	 * date() as well.
+	 *
+	 * @deprecated	3.1.3	Use PHP's native date() with DateTime constants
+	 *
+	 * @param	string	$fmt = 'DATE_RFC822'	the chosen format
+	 * @param	int	$time = NULL		Unix timestamp
+	 * @return	string
+	 */
+	function standard_date($fmt = 'DATE_RFC822', $time = NULL)
+	{
+		if (empty($time))
+		{
+			$time = now();
+		}
+
+		// Procedural style pre-defined constants from the DateTime extension
+		if (strpos($fmt, 'DATE_') !== 0 OR defined($fmt) === FALSE)
+		{
+			return FALSE;
+		}
+
+		return date(constant($fmt), $time);
+	}
+}
+
+// ------------------------------------------------------------------------
+
 if ( ! function_exists('timespan'))
 {
 	/**
@@ -446,6 +482,72 @@ if ( ! function_exists('human_to_unix'))
 		}
 
 		return mktime($hour, $min, $sec, $month, $day, $year);
+	}
+}
+
+// ------------------------------------------------------------------------
+
+if ( ! function_exists('nice_date'))
+{
+	/**
+	 * Turns many "reasonably-date-like" strings into something
+	 * that is actually useful. This only works for dates after unix epoch.
+	 *
+	 * @deprecated	3.1.3	Use DateTime::createFromFormat($input_format, $input)->format($output_format);
+	 * @param	string	The terribly formatted date-like string
+	 * @param	string	Date format to return (same as php date function)
+	 * @return	string
+	 */
+	function nice_date($bad_date = '', $format = FALSE)
+	{
+		if (empty($bad_date))
+		{
+			return 'Unknown';
+		}
+		elseif (empty($format))
+		{
+			$format = 'U';
+		}
+
+		// Date like: YYYYMM
+		if (preg_match('/^\d{6}$/i', $bad_date))
+		{
+			if (in_array(substr($bad_date, 0, 2), array('19', '20')))
+			{
+				$year  = substr($bad_date, 0, 4);
+				$month = substr($bad_date, 4, 2);
+			}
+			else
+			{
+				$month  = substr($bad_date, 0, 2);
+				$year   = substr($bad_date, 2, 4);
+			}
+
+			return date($format, strtotime($year.'-'.$month.'-01'));
+		}
+
+		// Date Like: YYYYMMDD
+		if (preg_match('/^\d{8}$/i', $bad_date, $matches))
+		{
+			return DateTime::createFromFormat('Ymd', $bad_date)->format($format);
+		}
+
+		// Date Like: MM-DD-YYYY __or__ M-D-YYYY (or anything in between)
+		if (preg_match('/^(\d{1,2})-(\d{1,2})-(\d{4})$/i', $bad_date, $matches))
+		{
+			return date($format, strtotime($matches[3].'-'.$matches[1].'-'.$matches[2]));
+		}
+
+		// Any other kind of string, when converted into UNIX time,
+		// produces "0 seconds after epoc..." is probably bad...
+		// return "Invalid Date".
+		if (date('U', strtotime($bad_date)) === '0')
+		{
+			return 'Invalid Date';
+		}
+
+		// It's probably a valid-ish date format already
+		return date($format, strtotime($bad_date));
 	}
 }
 

--- a/system/helpers/form_helper.php
+++ b/system/helpers/form_helper.php
@@ -676,6 +676,25 @@ if ( ! function_exists('form_close'))
 
 // ------------------------------------------------------------------------
 
+if ( ! function_exists('form_prep'))
+{
+	/**
+	 * Form Prep
+	 *
+	 * Formats text so that it can be safely placed in a form field in the event it has HTML tags.
+	 *
+	 * @deprecated	3.0.0	An alias for html_escape()
+	 * @param	string|string[]	$str		Value to escape
+	 * @return	string|string[]	Escaped values
+	 */
+	function form_prep($str)
+	{
+		return html_escape($str, TRUE);
+	}
+}
+
+// ------------------------------------------------------------------------
+
 if ( ! function_exists('set_value'))
 {
 	/**

--- a/system/helpers/html_helper.php
+++ b/system/helpers/html_helper.php
@@ -389,3 +389,37 @@ if ( ! function_exists('meta'))
 		return $str;
 	}
 }
+
+// ------------------------------------------------------------------------
+
+if ( ! function_exists('br'))
+{
+	/**
+	 * Generates HTML BR tags based on number supplied
+	 *
+	 * @deprecated	3.0.0	Use str_repeat() instead
+	 * @param	int	$count	Number of times to repeat the tag
+	 * @return	string
+	 */
+	function br($count = 1)
+	{
+		return str_repeat('<br />', $count);
+	}
+}
+
+// ------------------------------------------------------------------------
+
+if ( ! function_exists('nbs'))
+{
+	/**
+	 * Generates non-breaking space entities based on number supplied
+	 *
+	 * @deprecated	3.0.0	Use str_repeat() instead
+	 * @param	int
+	 * @return	string
+	 */
+	function nbs($num = 1)
+	{
+		return str_repeat('&nbsp;', $num);
+	}
+}

--- a/system/helpers/security_helper.php
+++ b/system/helpers/security_helper.php
@@ -83,6 +83,29 @@ if ( ! function_exists('sanitize_filename'))
 
 // ------------------------------------------------------------------------
 
+if ( ! function_exists('do_hash'))
+{
+	/**
+	 * Hash encode a string
+	 *
+	 * @deprecated	3.0.0	Use PHP's native hash() instead.
+	 * @param	string	$str
+	 * @param	string	$type = 'sha1'
+	 * @return	string
+	 */
+	function do_hash($str, $type = 'sha1')
+	{
+		if ( ! in_array(strtolower($type), hash_algos()))
+		{
+			$type = 'md5';
+		}
+
+		return hash($type, $str);
+	}
+}
+
+// ------------------------------------------------------------------------
+
 if ( ! function_exists('strip_image_tags'))
 {
 	/**

--- a/system/helpers/smiley_helper.php
+++ b/system/helpers/smiley_helper.php
@@ -1,0 +1,255 @@
+<?php
+/**
+ * CodeIgniter
+ *
+ * An open source application development framework for PHP
+ *
+ * This content is released under the MIT License (MIT)
+ *
+ * Copyright (c) 2014 - 2016, British Columbia Institute of Technology
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @package	CodeIgniter
+ * @author	EllisLab Dev Team
+ * @copyright	Copyright (c) 2008 - 2014, EllisLab, Inc. (https://ellislab.com/)
+ * @copyright	Copyright (c) 2014 - 2016, British Columbia Institute of Technology (http://bcit.ca/)
+ * @license	http://opensource.org/licenses/MIT	MIT License
+ * @link	https://codeigniter.com
+ * @since	Version 1.0.0
+ * @filesource
+ */
+defined('BASEPATH') OR exit('No direct script access allowed');
+
+/**
+ * CodeIgniter Smiley Helpers
+ *
+ * @package		CodeIgniter
+ * @subpackage	Helpers
+ * @category	Helpers
+ * @author		EllisLab Dev Team
+ * @link		https://codeigniter.com/user_guide/helpers/smiley_helper.html
+ * @deprecated	3.0.0	This helper is too specific for CI.
+ */
+
+// ------------------------------------------------------------------------
+
+if ( ! function_exists('smiley_js'))
+{
+	/**
+	 * Smiley Javascript
+	 *
+	 * Returns the javascript required for the smiley insertion.  Optionally takes
+	 * an array of aliases to loosely couple the smiley array to the view.
+	 *
+	 * @param	mixed	alias name or array of alias->field_id pairs
+	 * @param	string	field_id if alias name was passed in
+	 * @param	bool
+	 * @return	array
+	 */
+	function smiley_js($alias = '', $field_id = '', $inline = TRUE)
+	{
+		static $do_setup = TRUE;
+		$r = '';
+
+		if ($alias !== '' && ! is_array($alias))
+		{
+			$alias = array($alias => $field_id);
+		}
+
+		if ($do_setup === TRUE)
+		{
+			$do_setup = FALSE;
+			$m = array();
+
+			if (is_array($alias))
+			{
+				foreach ($alias as $name => $id)
+				{
+					$m[] = '"'.$name.'" : "'.$id.'"';
+				}
+			}
+
+			$m = '{'.implode(',', $m).'}';
+
+			$r .= <<<EOF
+			var smiley_map = {$m};
+
+			function insert_smiley(smiley, field_id) {
+				var el = document.getElementById(field_id), newStart;
+
+				if ( ! el && smiley_map[field_id]) {
+					el = document.getElementById(smiley_map[field_id]);
+
+					if ( ! el)
+						return false;
+				}
+
+				el.focus();
+				smiley = " " + smiley;
+
+				if ('selectionStart' in el) {
+					newStart = el.selectionStart + smiley.length;
+
+					el.value = el.value.substr(0, el.selectionStart) +
+									smiley +
+									el.value.substr(el.selectionEnd, el.value.length);
+					el.setSelectionRange(newStart, newStart);
+				}
+				else if (document.selection) {
+					document.selection.createRange().text = smiley;
+				}
+			}
+EOF;
+		}
+		elseif (is_array($alias))
+		{
+			foreach ($alias as $name => $id)
+			{
+				$r .= 'smiley_map["'.$name.'"] = "'.$id."\";\n";
+			}
+		}
+
+		return ($inline)
+			? '<script type="text/javascript" charset="utf-8">/*<![CDATA[ */'.$r.'// ]]></script>'
+			: $r;
+	}
+}
+
+// ------------------------------------------------------------------------
+
+if ( ! function_exists('get_clickable_smileys'))
+{
+	/**
+	 * Get Clickable Smileys
+	 *
+	 * Returns an array of image tag links that can be clicked to be inserted
+	 * into a form field.
+	 *
+	 * @param	string	the URL to the folder containing the smiley images
+	 * @param	array
+	 * @return	array
+	 */
+	function get_clickable_smileys($image_url, $alias = '')
+	{
+		// For backward compatibility with js_insert_smiley
+		if (is_array($alias))
+		{
+			$smileys = $alias;
+		}
+		elseif (FALSE === ($smileys = _get_smiley_array()))
+		{
+			return FALSE;
+		}
+
+		// Add a trailing slash to the file path if needed
+		$image_url = rtrim($image_url, '/').'/';
+
+		$used = array();
+		foreach ($smileys as $key => $val)
+		{
+			// Keep duplicates from being used, which can happen if the
+			// mapping array contains multiple identical replacements. For example:
+			// :-) and :) might be replaced with the same image so both smileys
+			// will be in the array.
+			if (isset($used[$smileys[$key][0]]))
+			{
+				continue;
+			}
+
+			$link[] = '<a href="javascript:void(0);" onclick="insert_smiley(\''.$key.'\', \''.$alias.'\')"><img src="'.$image_url.$smileys[$key][0].'" alt="'.$smileys[$key][3].'" style="width: '.$smileys[$key][1].'; height: '.$smileys[$key][2].'; border: 0;" /></a>';
+			$used[$smileys[$key][0]] = TRUE;
+		}
+
+		return $link;
+	}
+}
+
+// ------------------------------------------------------------------------
+
+if ( ! function_exists('parse_smileys'))
+{
+	/**
+	 * Parse Smileys
+	 *
+	 * Takes a string as input and swaps any contained smileys for the actual image
+	 *
+	 * @param	string	the text to be parsed
+	 * @param	string	the URL to the folder containing the smiley images
+	 * @param	array
+	 * @return	string
+	 */
+	function parse_smileys($str = '', $image_url = '', $smileys = NULL)
+	{
+		if ($image_url === '' OR ( ! is_array($smileys) && FALSE === ($smileys = _get_smiley_array())))
+		{
+			return $str;
+		}
+
+		// Add a trailing slash to the file path if needed
+		$image_url = rtrim($image_url, '/').'/';
+
+		foreach ($smileys as $key => $val)
+		{
+			$str = str_replace($key, '<img src="'.$image_url.$smileys[$key][0].'" alt="'.$smileys[$key][3].'" style="width: '.$smileys[$key][1].'; height: '.$smileys[$key][2].'; border: 0;" />', $str);
+		}
+
+		return $str;
+	}
+}
+
+// ------------------------------------------------------------------------
+
+if ( ! function_exists('_get_smiley_array'))
+{
+	/**
+	 * Get Smiley Array
+	 *
+	 * Fetches the config/smiley.php file
+	 *
+	 * @return	mixed
+	 */
+	function _get_smiley_array()
+	{
+		static $_smileys;
+
+		if ( ! is_array($_smileys))
+		{
+			if (file_exists(APPPATH.'config/smileys.php'))
+			{
+				include(APPPATH.'config/smileys.php');
+			}
+
+			if (file_exists(APPPATH.'config/'.ENVIRONMENT.'/smileys.php'))
+			{
+				include(APPPATH.'config/'.ENVIRONMENT.'/smileys.php');
+			}
+
+			if (empty($smileys) OR ! is_array($smileys))
+			{
+				$_smileys = array();
+				return FALSE;
+			}
+
+			$_smileys = $smileys;
+		}
+
+		return $_smileys;
+	}
+}

--- a/system/helpers/string_helper.php
+++ b/system/helpers/string_helper.php
@@ -227,8 +227,10 @@ if ( ! function_exists('random_string'))
 						break;
 				}
 				return substr(str_shuffle(str_repeat($pool, ceil($len / strlen($pool)))), 0, $len);
+			case 'unique':
 			case 'md5':
 				return md5(uniqid(mt_rand()));
+			case 'encrypt':
 			case 'sha1':
 				return sha1(uniqid(mt_rand(), TRUE));
 		}

--- a/system/helpers/string_helper.php
+++ b/system/helpers/string_helper.php
@@ -50,6 +50,32 @@ defined('BASEPATH') OR exit('No direct script access allowed');
 
 // ------------------------------------------------------------------------
 
+if ( ! function_exists('trim_slashes'))
+{
+	/**
+	 * Trim Slashes
+	 *
+	 * Removes any leading/trailing slashes from a string:
+	 *
+	 * /this/that/theother/
+	 *
+	 * becomes:
+	 *
+	 * this/that/theother
+	 *
+	 * @deprecated	3.0.0	This is just an alias for PHP's native trim()
+	 *
+	 * @param	string
+	 * @return	string
+	 */
+	function trim_slashes($str)
+	{
+		return trim($str, '/');
+	}
+}
+
+// ------------------------------------------------------------------------
+
 if ( ! function_exists('strip_slashes'))
 {
 	/**
@@ -252,5 +278,24 @@ if ( ! function_exists('alternator'))
 
 		$args = func_get_args();
 		return $args[($i++ % count($args))];
+	}
+}
+
+// ------------------------------------------------------------------------
+
+if ( ! function_exists('repeater'))
+{
+	/**
+	 * Repeater function
+	 *
+	 * @deprecated	3.0.0	Use PHP's native str_repeat() instead
+	 *
+	 * @param	string	$data	String to repeat
+	 * @param	int	$num	Number of repeats
+	 * @return	string
+	 */
+	function repeater($data, $num = 1)
+	{
+		return ($num > 0) ? str_repeat($data, $num) : '';
 	}
 }

--- a/system/helpers/url_helper.php
+++ b/system/helpers/url_helper.php
@@ -478,6 +478,15 @@ if ( ! function_exists('url_title'))
 	 */
 	function url_title($str, $separator = '-', $lowercase = FALSE)
 	{
+		if ($separator === 'dash')
+		{
+			$separator = '-';
+		}
+		elseif ($separator === 'underscore')
+		{
+			$separator = '_';
+		}
+
 		$q_separator = preg_quote($separator, '#');
 
 		$trans = array(

--- a/system/libraries/Form_validation.php
+++ b/system/libraries/Form_validation.php
@@ -106,6 +106,14 @@ class CI_Form_validation {
 	protected $error_string		= '';
 
 	/**
+	 * Whether the form data has been through validation and had errors
+	 *
+	 * @deprecated	3.0.6
+	 * @var bool
+	 */
+	protected $_safe_form_data	= FALSE;
+
+	/**
 	 * Custom data to validate
 	 *
 	 * @var array
@@ -479,6 +487,7 @@ class CI_Form_validation {
 
 		if ( ! empty($this->_error_array))
 		{
+			$this->_safe_form_data = TRUE;
 			return FALSE;
 		}
 
@@ -1520,6 +1529,38 @@ class CI_Form_validation {
 	public function valid_base64($str)
 	{
 		return (base64_encode(base64_decode($str)) === $str);
+	}
+
+	// --------------------------------------------------------------------
+
+	/**
+	 * Prep data for form
+	 *
+	 * This function allows HTML to be safely shown in a form.
+	 * Special characters are converted.
+	 *
+	 * @deprecated	3.0.6	Not used anywhere within the framework and pretty much useless
+	 * @param	mixed	$data	Input data
+	 * @return	mixed
+	 */
+	public function prep_for_form($data)
+	{
+		if ($this->_safe_form_data === FALSE OR empty($data))
+		{
+			return $data;
+		}
+
+		if (is_array($data))
+		{
+			foreach ($data as $key => $val)
+			{
+				$data[$key] = $this->prep_for_form($val);
+			}
+
+			return $data;
+		}
+
+		return str_replace(array("'", '"', '<', '>'), array('&#39;', '&quot;', '&lt;', '&gt;'), stripslashes($data));
 	}
 
 	// --------------------------------------------------------------------

--- a/system/libraries/Javascript.php
+++ b/system/libraries/Javascript.php
@@ -1,0 +1,870 @@
+<?php
+/**
+ * CodeIgniter
+ *
+ * An open source application development framework for PHP
+ *
+ * This content is released under the MIT License (MIT)
+ *
+ * Copyright (c) 2014 - 2016, British Columbia Institute of Technology
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @package	CodeIgniter
+ * @author	EllisLab Dev Team
+ * @copyright	Copyright (c) 2008 - 2014, EllisLab, Inc. (https://ellislab.com/)
+ * @copyright	Copyright (c) 2014 - 2016, British Columbia Institute of Technology (http://bcit.ca/)
+ * @license	http://opensource.org/licenses/MIT	MIT License
+ * @link	https://codeigniter.com
+ * @since	Version 1.0.0
+ * @filesource
+ */
+defined('BASEPATH') OR exit('No direct script access allowed');
+
+/**
+ * Javascript Class
+ *
+ * @package		CodeIgniter
+ * @subpackage	Libraries
+ * @category	Javascript
+ * @author		EllisLab Dev Team
+ * @link		https://codeigniter.com/user_guide/libraries/javascript.html
+ * @deprecated	3.0.0	This was never a good idea in the first place.
+ */
+class CI_Javascript {
+
+	/**
+	 * CI Singleton
+	 *
+	 * @var	object
+	 */
+	protected $CI;
+
+	/**
+	 * JavaScript library driver instance
+	 *
+	 * @var	object
+	 */
+	public $js;
+
+	/**
+	 * JavaScript location
+	 *
+	 * @var	string
+	 */
+	protected $_javascript_location = 'js';
+
+	// --------------------------------------------------------------------
+
+	/**
+	 * Constructor
+	 *
+	 * @param	array	$params
+	 * @return	void
+	 */
+	public function __construct($params = array())
+	{
+		$defaults = array('js_library_driver' => 'jquery', 'autoload' => TRUE);
+
+		foreach ($defaults as $key => $val)
+		{
+			if (isset($params[$key]) && $params[$key] !== '')
+			{
+				$defaults[$key] = $params[$key];
+			}
+		}
+
+		extract($defaults);
+
+		$this->CI =& get_instance();
+
+		// load the requested js library
+		$this->CI->load->library('Javascript/'.$js_library_driver, array('autoload' => $autoload));
+		// make js to refer to current library
+		$this->js =& $this->CI->$js_library_driver;
+
+		log_message('info', 'Javascript Class Initialized and loaded. Driver used: '.$js_library_driver);
+	}
+
+	// --------------------------------------------------------------------
+	// Event Code
+	// --------------------------------------------------------------------
+
+	/**
+	 * Blur
+	 *
+	 * Outputs a javascript library blur event
+	 *
+	 * @param	string	The element to attach the event to
+	 * @param	string	The code to execute
+	 * @return	string
+	 */
+	public function blur($element = 'this', $js = '')
+	{
+		return $this->js->_blur($element, $js);
+	}
+
+	// --------------------------------------------------------------------
+
+	/**
+	 * Change
+	 *
+	 * Outputs a javascript library change event
+	 *
+	 * @param	string	The element to attach the event to
+	 * @param	string	The code to execute
+	 * @return	string
+	 */
+	public function change($element = 'this', $js = '')
+	{
+		return $this->js->_change($element, $js);
+	}
+
+	// --------------------------------------------------------------------
+
+	/**
+	 * Click
+	 *
+	 * Outputs a javascript library click event
+	 *
+	 * @param	string	The element to attach the event to
+	 * @param	string	The code to execute
+	 * @param	bool	whether or not to return false
+	 * @return	string
+	 */
+	public function click($element = 'this', $js = '', $ret_false = TRUE)
+	{
+		return $this->js->_click($element, $js, $ret_false);
+	}
+
+	// --------------------------------------------------------------------
+
+	/**
+	 * Double Click
+	 *
+	 * Outputs a javascript library dblclick event
+	 *
+	 * @param	string	The element to attach the event to
+	 * @param	string	The code to execute
+	 * @return	string
+	 */
+	public function dblclick($element = 'this', $js = '')
+	{
+		return $this->js->_dblclick($element, $js);
+	}
+
+	// --------------------------------------------------------------------
+
+	/**
+	 * Error
+	 *
+	 * Outputs a javascript library error event
+	 *
+	 * @param	string	The element to attach the event to
+	 * @param	string	The code to execute
+	 * @return	string
+	 */
+	public function error($element = 'this', $js = '')
+	{
+		return $this->js->_error($element, $js);
+	}
+
+	// --------------------------------------------------------------------
+
+	/**
+	 * Focus
+	 *
+	 * Outputs a javascript library focus event
+	 *
+	 * @param	string	The element to attach the event to
+	 * @param	string	The code to execute
+	 * @return	string
+	 */
+	public function focus($element = 'this', $js = '')
+	{
+		return $this->js->_focus($element, $js);
+	}
+
+	// --------------------------------------------------------------------
+
+	/**
+	 * Hover
+	 *
+	 * Outputs a javascript library hover event
+	 *
+	 * @param	string	- element
+	 * @param	string	- Javascript code for mouse over
+	 * @param	string	- Javascript code for mouse out
+	 * @return	string
+	 */
+	public function hover($element = 'this', $over = '', $out = '')
+	{
+		return $this->js->_hover($element, $over, $out);
+	}
+
+	// --------------------------------------------------------------------
+
+	/**
+	 * Keydown
+	 *
+	 * Outputs a javascript library keydown event
+	 *
+	 * @param	string	The element to attach the event to
+	 * @param	string	The code to execute
+	 * @return	string
+	 */
+	public function keydown($element = 'this', $js = '')
+	{
+		return $this->js->_keydown($element, $js);
+	}
+
+	// --------------------------------------------------------------------
+
+	/**
+	 * Keyup
+	 *
+	 * Outputs a javascript library keydown event
+	 *
+	 * @param	string	The element to attach the event to
+	 * @param	string	The code to execute
+	 * @return	string
+	 */
+	public function keyup($element = 'this', $js = '')
+	{
+		return $this->js->_keyup($element, $js);
+	}
+
+	// --------------------------------------------------------------------
+
+	/**
+	 * Load
+	 *
+	 * Outputs a javascript library load event
+	 *
+	 * @param	string	The element to attach the event to
+	 * @param	string	The code to execute
+	 * @return	string
+	 */
+	public function load($element = 'this', $js = '')
+	{
+		return $this->js->_load($element, $js);
+	}
+
+	// --------------------------------------------------------------------
+
+	/**
+	 * Mousedown
+	 *
+	 * Outputs a javascript library mousedown event
+	 *
+	 * @param	string	The element to attach the event to
+	 * @param	string	The code to execute
+	 * @return	string
+	 */
+	public function mousedown($element = 'this', $js = '')
+	{
+		return $this->js->_mousedown($element, $js);
+	}
+
+	// --------------------------------------------------------------------
+
+	/**
+	 * Mouse Out
+	 *
+	 * Outputs a javascript library mouseout event
+	 *
+	 * @param	string	The element to attach the event to
+	 * @param	string	The code to execute
+	 * @return	string
+	 */
+	public function mouseout($element = 'this', $js = '')
+	{
+		return $this->js->_mouseout($element, $js);
+	}
+
+	// --------------------------------------------------------------------
+
+	/**
+	 * Mouse Over
+	 *
+	 * Outputs a javascript library mouseover event
+	 *
+	 * @param	string	The element to attach the event to
+	 * @param	string	The code to execute
+	 * @return	string
+	 */
+	public function mouseover($element = 'this', $js = '')
+	{
+		return $this->js->_mouseover($element, $js);
+	}
+
+	// --------------------------------------------------------------------
+
+	/**
+	 * Mouseup
+	 *
+	 * Outputs a javascript library mouseup event
+	 *
+	 * @param	string	The element to attach the event to
+	 * @param	string	The code to execute
+	 * @return	string
+	 */
+	public function mouseup($element = 'this', $js = '')
+	{
+		return $this->js->_mouseup($element, $js);
+	}
+
+	// --------------------------------------------------------------------
+
+	/**
+	 * Output
+	 *
+	 * Outputs the called javascript to the screen
+	 *
+	 * @param	string	The code to output
+	 * @return	string
+	 */
+	public function output($js)
+	{
+		return $this->js->_output($js);
+	}
+
+	// --------------------------------------------------------------------
+
+	/**
+	 * Ready
+	 *
+	 * Outputs a javascript library mouseup event
+	 *
+	 * @param	string	$js	Code to execute
+	 * @return	string
+	 */
+	public function ready($js)
+	{
+		return $this->js->_document_ready($js);
+	}
+
+	// --------------------------------------------------------------------
+
+	/**
+	 * Resize
+	 *
+	 * Outputs a javascript library resize event
+	 *
+	 * @param	string	The element to attach the event to
+	 * @param	string	The code to execute
+	 * @return	string
+	 */
+	public function resize($element = 'this', $js = '')
+	{
+		return $this->js->_resize($element, $js);
+	}
+
+	// --------------------------------------------------------------------
+
+	/**
+	 * Scroll
+	 *
+	 * Outputs a javascript library scroll event
+	 *
+	 * @param	string	The element to attach the event to
+	 * @param	string	The code to execute
+	 * @return	string
+	 */
+	public function scroll($element = 'this', $js = '')
+	{
+		return $this->js->_scroll($element, $js);
+	}
+
+	// --------------------------------------------------------------------
+
+	/**
+	 * Unload
+	 *
+	 * Outputs a javascript library unload event
+	 *
+	 * @param	string	The element to attach the event to
+	 * @param	string	The code to execute
+	 * @return	string
+	 */
+	public function unload($element = 'this', $js = '')
+	{
+		return $this->js->_unload($element, $js);
+	}
+
+	// --------------------------------------------------------------------
+	// Effects
+	// --------------------------------------------------------------------
+
+	/**
+	 * Add Class
+	 *
+	 * Outputs a javascript library addClass event
+	 *
+	 * @param	string	- element
+	 * @param	string	- Class to add
+	 * @return	string
+	 */
+	public function addClass($element = 'this', $class = '')
+	{
+		return $this->js->_addClass($element, $class);
+	}
+
+	// --------------------------------------------------------------------
+
+	/**
+	 * Animate
+	 *
+	 * Outputs a javascript library animate event
+	 *
+	 * @param	string	$element = 'this'
+	 * @param	array	$params = array()
+	 * @param	mixed	$speed			'slow', 'normal', 'fast', or time in milliseconds
+	 * @param	string	$extra
+	 * @return	string
+	 */
+	public function animate($element = 'this', $params = array(), $speed = '', $extra = '')
+	{
+		return $this->js->_animate($element, $params, $speed, $extra);
+	}
+
+	// --------------------------------------------------------------------
+
+	/**
+	 * Fade In
+	 *
+	 * Outputs a javascript library hide event
+	 *
+	 * @param	string	- element
+	 * @param	string	- One of 'slow', 'normal', 'fast', or time in milliseconds
+	 * @param	string	- Javascript callback function
+	 * @return	string
+	 */
+	public function fadeIn($element = 'this', $speed = '', $callback = '')
+	{
+		return $this->js->_fadeIn($element, $speed, $callback);
+	}
+
+	// --------------------------------------------------------------------
+
+	/**
+	 * Fade Out
+	 *
+	 * Outputs a javascript library hide event
+	 *
+	 * @param	string	- element
+	 * @param	string	- One of 'slow', 'normal', 'fast', or time in milliseconds
+	 * @param	string	- Javascript callback function
+	 * @return	string
+	 */
+	public function fadeOut($element = 'this', $speed = '', $callback = '')
+	{
+		return $this->js->_fadeOut($element, $speed, $callback);
+	}
+	// --------------------------------------------------------------------
+
+	/**
+	 * Slide Up
+	 *
+	 * Outputs a javascript library slideUp event
+	 *
+	 * @param	string	- element
+	 * @param	string	- One of 'slow', 'normal', 'fast', or time in milliseconds
+	 * @param	string	- Javascript callback function
+	 * @return	string
+	 */
+	public function slideUp($element = 'this', $speed = '', $callback = '')
+	{
+		return $this->js->_slideUp($element, $speed, $callback);
+
+	}
+
+	// --------------------------------------------------------------------
+
+	/**
+	 * Remove Class
+	 *
+	 * Outputs a javascript library removeClass event
+	 *
+	 * @param	string	- element
+	 * @param	string	- Class to add
+	 * @return	string
+	 */
+	public function removeClass($element = 'this', $class = '')
+	{
+		return $this->js->_removeClass($element, $class);
+	}
+
+	// --------------------------------------------------------------------
+
+	/**
+	 * Slide Down
+	 *
+	 * Outputs a javascript library slideDown event
+	 *
+	 * @param	string	- element
+	 * @param	string	- One of 'slow', 'normal', 'fast', or time in milliseconds
+	 * @param	string	- Javascript callback function
+	 * @return	string
+	 */
+	public function slideDown($element = 'this', $speed = '', $callback = '')
+	{
+		return $this->js->_slideDown($element, $speed, $callback);
+	}
+
+	// --------------------------------------------------------------------
+
+	/**
+	 * Slide Toggle
+	 *
+	 * Outputs a javascript library slideToggle event
+	 *
+	 * @param	string	- element
+	 * @param	string	- One of 'slow', 'normal', 'fast', or time in milliseconds
+	 * @param	string	- Javascript callback function
+	 * @return	string
+	 */
+	public function slideToggle($element = 'this', $speed = '', $callback = '')
+	{
+		return $this->js->_slideToggle($element, $speed, $callback);
+
+	}
+
+	// --------------------------------------------------------------------
+
+	/**
+	 * Hide
+	 *
+	 * Outputs a javascript library hide action
+	 *
+	 * @param	string	- element
+	 * @param	string	- One of 'slow', 'normal', 'fast', or time in milliseconds
+	 * @param	string	- Javascript callback function
+	 * @return	string
+	 */
+	public function hide($element = 'this', $speed = '', $callback = '')
+	{
+		return $this->js->_hide($element, $speed, $callback);
+	}
+
+	// --------------------------------------------------------------------
+
+	/**
+	 * Toggle
+	 *
+	 * Outputs a javascript library toggle event
+	 *
+	 * @param	string	- element
+	 * @return	string
+	 */
+	public function toggle($element = 'this')
+	{
+		return $this->js->_toggle($element);
+
+	}
+
+	// --------------------------------------------------------------------
+
+	/**
+	 * Toggle Class
+	 *
+	 * Outputs a javascript library toggle class event
+	 *
+	 * @param	string	$element = 'this'
+	 * @param	string	$class = ''
+	 * @return	string
+	 */
+	public function toggleClass($element = 'this', $class = '')
+	{
+		return $this->js->_toggleClass($element, $class);
+	}
+
+	// --------------------------------------------------------------------
+
+	/**
+	 * Show
+	 *
+	 * Outputs a javascript library show event
+	 *
+	 * @param	string	- element
+	 * @param	string	- One of 'slow', 'normal', 'fast', or time in milliseconds
+	 * @param	string	- Javascript callback function
+	 * @return	string
+	 */
+	public function show($element = 'this', $speed = '', $callback = '')
+	{
+		return $this->js->_show($element, $speed, $callback);
+	}
+
+	// --------------------------------------------------------------------
+
+	/**
+	 * Compile
+	 *
+	 * gather together all script needing to be output
+	 *
+	 * @param	string	$view_var
+	 * @param	bool	$script_tags
+	 * @return	string
+	 */
+	public function compile($view_var = 'script_foot', $script_tags = TRUE)
+	{
+		$this->js->_compile($view_var, $script_tags);
+	}
+
+	// --------------------------------------------------------------------
+
+	/**
+	 * Clear Compile
+	 *
+	 * Clears any previous javascript collected for output
+	 *
+	 * @return	void
+	 */
+	public function clear_compile()
+	{
+		$this->js->_clear_compile();
+	}
+
+	// --------------------------------------------------------------------
+
+	/**
+	 * External
+	 *
+	 * Outputs a <script> tag with the source as an external js file
+	 *
+	 * @param	string	$external_file
+	 * @param	bool	$relative
+	 * @return	string
+	 */
+	public function external($external_file = '', $relative = FALSE)
+	{
+		if ($external_file !== '')
+		{
+			$this->_javascript_location = $external_file;
+		}
+		elseif ($this->CI->config->item('javascript_location') !== '')
+		{
+			$this->_javascript_location = $this->CI->config->item('javascript_location');
+		}
+
+		if ($relative === TRUE OR stripos($external_file, 'http://') === 0 OR stripos($external_file, 'https://') === 0)
+		{
+			$str = $this->_open_script($external_file);
+		}
+		elseif (stripos($this->_javascript_location, 'http://') !== FALSE)
+		{
+			$str = $this->_open_script($this->_javascript_location.$external_file);
+		}
+		else
+		{
+			$str = $this->_open_script($this->CI->config->slash_item('base_url').$this->_javascript_location.$external_file);
+		}
+
+		return $str.$this->_close_script();
+	}
+
+	// --------------------------------------------------------------------
+
+	/**
+	 * Inline
+	 *
+	 * Outputs a <script> tag
+	 *
+	 * @param	string	The element to attach the event to
+	 * @param	bool	If a CDATA section should be added
+	 * @return	string
+	 */
+	public function inline($script, $cdata = TRUE)
+	{
+		return $this->_open_script()
+			. ($cdata ? "\n// <![CDATA[\n".$script."\n// ]]>\n" : "\n".$script."\n")
+			. $this->_close_script();
+	}
+
+	// --------------------------------------------------------------------
+
+	/**
+	 * Open Script
+	 *
+	 * Outputs an opening <script>
+	 *
+	 * @param	string
+	 * @return	string
+	 */
+	protected function _open_script($src = '')
+	{
+		return '<script type="text/javascript" charset="'.strtolower($this->CI->config->item('charset')).'"'
+			.($src === '' ? '>' : ' src="'.$src.'">');
+	}
+
+	// --------------------------------------------------------------------
+
+	/**
+	 * Close Script
+	 *
+	 * Outputs an closing </script>
+	 *
+	 * @param	string
+	 * @return	string
+	 */
+	protected function _close_script($extra = "\n")
+	{
+		return '</script>'.$extra;
+	}
+
+	// --------------------------------------------------------------------
+	// AJAX-Y STUFF - still a testbed
+	// --------------------------------------------------------------------
+
+	/**
+	 * Update
+	 *
+	 * Outputs a javascript library slideDown event
+	 *
+	 * @param	string	- element
+	 * @param	string	- One of 'slow', 'normal', 'fast', or time in milliseconds
+	 * @param	string	- Javascript callback function
+	 * @return	string
+	 */
+	public function update($element = 'this', $speed = '', $callback = '')
+	{
+		return $this->js->_updater($element, $speed, $callback);
+	}
+
+	// --------------------------------------------------------------------
+
+	/**
+	 * Generate JSON
+	 *
+	 * Can be passed a database result or associative array and returns a JSON formatted string
+	 *
+	 * @param	mixed	result set or array
+	 * @param	bool	match array types (defaults to objects)
+	 * @return	string	a json formatted string
+	 */
+	public function generate_json($result = NULL, $match_array_type = FALSE)
+	{
+		// JSON data can optionally be passed to this function
+		// either as a database result object or an array, or a user supplied array
+		if ($result !== NULL)
+		{
+			if (is_object($result))
+			{
+				$json_result = is_callable(array($result, 'result_array')) ? $result->result_array() : (array) $result;
+			}
+			elseif (is_array($result))
+			{
+				$json_result = $result;
+			}
+			else
+			{
+				return $this->_prep_args($result);
+			}
+		}
+		else
+		{
+			return 'null';
+		}
+
+		$json = array();
+		$_is_assoc = TRUE;
+
+		if ( ! is_array($json_result) && empty($json_result))
+		{
+			show_error('Generate JSON Failed - Illegal key, value pair.');
+		}
+		elseif ($match_array_type)
+		{
+			$_is_assoc = $this->_is_associative_array($json_result);
+		}
+
+		foreach ($json_result as $k => $v)
+		{
+			if ($_is_assoc)
+			{
+				$json[] = $this->_prep_args($k, TRUE).':'.$this->generate_json($v, $match_array_type);
+			}
+			else
+			{
+				$json[] = $this->generate_json($v, $match_array_type);
+			}
+		}
+
+		$json = implode(',', $json);
+
+		return $_is_assoc ? '{'.$json.'}' : '['.$json.']';
+
+	}
+
+	// --------------------------------------------------------------------
+
+	/**
+	 * Is associative array
+	 *
+	 * Checks for an associative array
+	 *
+	 * @param	array
+	 * @return	bool
+	 */
+	protected function _is_associative_array($arr)
+	{
+		foreach (array_keys($arr) as $key => $val)
+		{
+			if ($key !== $val)
+			{
+				return TRUE;
+			}
+		}
+
+		return FALSE;
+	}
+
+	// --------------------------------------------------------------------
+
+	/**
+	 * Prep Args
+	 *
+	 * Ensures a standard json value and escapes values
+	 *
+	 * @param	mixed	$result
+	 * @param	bool	$is_key = FALSE
+	 * @return	string
+	 */
+	protected function _prep_args($result, $is_key = FALSE)
+	{
+		if ($result === NULL)
+		{
+			return 'null';
+		}
+		elseif (is_bool($result))
+		{
+			return ($result === TRUE) ? 'true' : 'false';
+		}
+		elseif (is_string($result) OR $is_key)
+		{
+			return '"'.str_replace(array('\\', "\t", "\n", "\r", '"', '/'), array('\\\\', '\\t', '\\n', "\\r", '\"', '\/'), $result).'"';
+		}
+		elseif (is_scalar($result))
+		{
+			return $result;
+		}
+	}
+
+}

--- a/system/libraries/Javascript/Jquery.php
+++ b/system/libraries/Javascript/Jquery.php
@@ -1,0 +1,1076 @@
+<?php
+/**
+ * CodeIgniter
+ *
+ * An open source application development framework for PHP
+ *
+ * This content is released under the MIT License (MIT)
+ *
+ * Copyright (c) 2014 - 2016, British Columbia Institute of Technology
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @package	CodeIgniter
+ * @author	EllisLab Dev Team
+ * @copyright	Copyright (c) 2008 - 2014, EllisLab, Inc. (https://ellislab.com/)
+ * @copyright	Copyright (c) 2014 - 2016, British Columbia Institute of Technology (http://bcit.ca/)
+ * @license	http://opensource.org/licenses/MIT	MIT License
+ * @link	https://codeigniter.com
+ * @since	Version 1.0.0
+ * @filesource
+ */
+defined('BASEPATH') OR exit('No direct script access allowed');
+
+/**
+ * Jquery Class
+ *
+ * @package		CodeIgniter
+ * @subpackage	Libraries
+ * @category	Loader
+ * @author		EllisLab Dev Team
+ * @link		https://codeigniter.com/user_guide/libraries/javascript.html
+ */
+class CI_Jquery extends CI_Javascript {
+
+	/**
+	 * JavaScript directory location
+	 *
+	 * @var	string
+	 */
+	protected $_javascript_folder = 'js';
+
+	/**
+	 * JQuery code for load
+	 *
+	 * @var	array
+	 */
+	public $jquery_code_for_load = array();
+
+	/**
+	 * JQuery code for compile
+	 *
+	 * @var	array
+	 */
+	public $jquery_code_for_compile = array();
+
+	/**
+	 * JQuery corner active flag
+	 *
+	 * @var	bool
+	 */
+	public $jquery_corner_active = FALSE;
+
+	/**
+	 * JQuery table sorter active flag
+	 *
+	 * @var	bool
+	 */
+	public $jquery_table_sorter_active = FALSE;
+
+	/**
+	 * JQuery table sorter pager active
+	 *
+	 * @var	bool
+	 */
+	public $jquery_table_sorter_pager_active = FALSE;
+
+	/**
+	 * JQuery AJAX image
+	 *
+	 * @var	string
+	 */
+	public $jquery_ajax_img = '';
+
+	// --------------------------------------------------------------------
+
+	/**
+	 * Constructor
+	 *
+	 * @param	array	$params
+	 * @return	void
+	 */
+	public function __construct($params)
+	{
+		$this->CI =& get_instance();
+		extract($params);
+
+		if ($autoload === TRUE)
+		{
+			$this->script();
+		}
+
+		log_message('info', 'Jquery Class Initialized');
+	}
+
+	// --------------------------------------------------------------------
+	// Event Code
+	// --------------------------------------------------------------------
+
+	/**
+	 * Blur
+	 *
+	 * Outputs a jQuery blur event
+	 *
+	 * @param	string	The element to attach the event to
+	 * @param	string	The code to execute
+	 * @return	string
+	 */
+	protected function _blur($element = 'this', $js = '')
+	{
+		return $this->_add_event($element, $js, 'blur');
+	}
+
+	// --------------------------------------------------------------------
+
+	/**
+	 * Change
+	 *
+	 * Outputs a jQuery change event
+	 *
+	 * @param	string	The element to attach the event to
+	 * @param	string	The code to execute
+	 * @return	string
+	 */
+	protected function _change($element = 'this', $js = '')
+	{
+		return $this->_add_event($element, $js, 'change');
+	}
+
+	// --------------------------------------------------------------------
+
+	/**
+	 * Click
+	 *
+	 * Outputs a jQuery click event
+	 *
+	 * @param	string	The element to attach the event to
+	 * @param	string	The code to execute
+	 * @param	bool	whether or not to return false
+	 * @return	string
+	 */
+	protected function _click($element = 'this', $js = '', $ret_false = TRUE)
+	{
+		is_array($js) OR $js = array($js);
+
+		if ($ret_false)
+		{
+			$js[] = 'return false;';
+		}
+
+		return $this->_add_event($element, $js, 'click');
+	}
+
+	// --------------------------------------------------------------------
+
+	/**
+	 * Double Click
+	 *
+	 * Outputs a jQuery dblclick event
+	 *
+	 * @param	string	The element to attach the event to
+	 * @param	string	The code to execute
+	 * @return	string
+	 */
+	protected function _dblclick($element = 'this', $js = '')
+	{
+		return $this->_add_event($element, $js, 'dblclick');
+	}
+
+	// --------------------------------------------------------------------
+
+	/**
+	 * Error
+	 *
+	 * Outputs a jQuery error event
+	 *
+	 * @param	string	The element to attach the event to
+	 * @param	string	The code to execute
+	 * @return	string
+	 */
+	protected function _error($element = 'this', $js = '')
+	{
+		return $this->_add_event($element, $js, 'error');
+	}
+
+	// --------------------------------------------------------------------
+
+	/**
+	 * Focus
+	 *
+	 * Outputs a jQuery focus event
+	 *
+	 * @param	string	The element to attach the event to
+	 * @param	string	The code to execute
+	 * @return	string
+	 */
+	protected function _focus($element = 'this', $js = '')
+	{
+		return $this->_add_event($element, $js, 'focus');
+	}
+
+	// --------------------------------------------------------------------
+
+	/**
+	 * Hover
+	 *
+	 * Outputs a jQuery hover event
+	 *
+	 * @param	string	- element
+	 * @param	string	- Javascript code for mouse over
+	 * @param	string	- Javascript code for mouse out
+	 * @return	string
+	 */
+	protected function _hover($element = 'this', $over = '', $out = '')
+	{
+		$event = "\n\t$(".$this->_prep_element($element).").hover(\n\t\tfunction()\n\t\t{\n\t\t\t{$over}\n\t\t}, \n\t\tfunction()\n\t\t{\n\t\t\t{$out}\n\t\t});\n";
+
+		$this->jquery_code_for_compile[] = $event;
+
+		return $event;
+	}
+
+	// --------------------------------------------------------------------
+
+	/**
+	 * Keydown
+	 *
+	 * Outputs a jQuery keydown event
+	 *
+	 * @param	string	The element to attach the event to
+	 * @param	string	The code to execute
+	 * @return	string
+	 */
+	protected function _keydown($element = 'this', $js = '')
+	{
+		return $this->_add_event($element, $js, 'keydown');
+	}
+
+	// --------------------------------------------------------------------
+
+	/**
+	 * Keyup
+	 *
+	 * Outputs a jQuery keydown event
+	 *
+	 * @param	string	The element to attach the event to
+	 * @param	string	The code to execute
+	 * @return	string
+	 */
+	protected function _keyup($element = 'this', $js = '')
+	{
+		return $this->_add_event($element, $js, 'keyup');
+	}
+
+	// --------------------------------------------------------------------
+
+	/**
+	 * Load
+	 *
+	 * Outputs a jQuery load event
+	 *
+	 * @param	string	The element to attach the event to
+	 * @param	string	The code to execute
+	 * @return	string
+	 */
+	protected function _load($element = 'this', $js = '')
+	{
+		return $this->_add_event($element, $js, 'load');
+	}
+
+	// --------------------------------------------------------------------
+
+	/**
+	 * Mousedown
+	 *
+	 * Outputs a jQuery mousedown event
+	 *
+	 * @param	string	The element to attach the event to
+	 * @param	string	The code to execute
+	 * @return	string
+	 */
+	protected function _mousedown($element = 'this', $js = '')
+	{
+		return $this->_add_event($element, $js, 'mousedown');
+	}
+
+	// --------------------------------------------------------------------
+
+	/**
+	 * Mouse Out
+	 *
+	 * Outputs a jQuery mouseout event
+	 *
+	 * @param	string	The element to attach the event to
+	 * @param	string	The code to execute
+	 * @return	string
+	 */
+	protected function _mouseout($element = 'this', $js = '')
+	{
+		return $this->_add_event($element, $js, 'mouseout');
+	}
+
+	// --------------------------------------------------------------------
+
+	/**
+	 * Mouse Over
+	 *
+	 * Outputs a jQuery mouseover event
+	 *
+	 * @param	string	The element to attach the event to
+	 * @param	string	The code to execute
+	 * @return	string
+	 */
+	protected function _mouseover($element = 'this', $js = '')
+	{
+		return $this->_add_event($element, $js, 'mouseover');
+	}
+
+	// --------------------------------------------------------------------
+
+	/**
+	 * Mouseup
+	 *
+	 * Outputs a jQuery mouseup event
+	 *
+	 * @param	string	The element to attach the event to
+	 * @param	string	The code to execute
+	 * @return	string
+	 */
+	protected function _mouseup($element = 'this', $js = '')
+	{
+		return $this->_add_event($element, $js, 'mouseup');
+	}
+
+	// --------------------------------------------------------------------
+
+	/**
+	 * Output
+	 *
+	 * Outputs script directly
+	 *
+	 * @param	array	$array_js = array()
+	 * @return	void
+	 */
+	protected function _output($array_js = array())
+	{
+		if ( ! is_array($array_js))
+		{
+			$array_js = array($array_js);
+		}
+
+		foreach ($array_js as $js)
+		{
+			$this->jquery_code_for_compile[] = "\t".$js."\n";
+		}
+	}
+
+	// --------------------------------------------------------------------
+
+	/**
+	 * Resize
+	 *
+	 * Outputs a jQuery resize event
+	 *
+	 * @param	string	The element to attach the event to
+	 * @param	string	The code to execute
+	 * @return	string
+	 */
+	protected function _resize($element = 'this', $js = '')
+	{
+		return $this->_add_event($element, $js, 'resize');
+	}
+
+	// --------------------------------------------------------------------
+
+	/**
+	 * Scroll
+	 *
+	 * Outputs a jQuery scroll event
+	 *
+	 * @param	string	The element to attach the event to
+	 * @param	string	The code to execute
+	 * @return	string
+	 */
+	protected function _scroll($element = 'this', $js = '')
+	{
+		return $this->_add_event($element, $js, 'scroll');
+	}
+
+	// --------------------------------------------------------------------
+
+	/**
+	 * Unload
+	 *
+	 * Outputs a jQuery unload event
+	 *
+	 * @param	string	The element to attach the event to
+	 * @param	string	The code to execute
+	 * @return	string
+	 */
+	protected function _unload($element = 'this', $js = '')
+	{
+		return $this->_add_event($element, $js, 'unload');
+	}
+
+	// --------------------------------------------------------------------
+	// Effects
+	// --------------------------------------------------------------------
+
+	/**
+	 * Add Class
+	 *
+	 * Outputs a jQuery addClass event
+	 *
+	 * @param	string	$element
+	 * @param	string	$class
+	 * @return	string
+	 */
+	protected function _addClass($element = 'this', $class = '')
+	{
+		$element = $this->_prep_element($element);
+		return '$('.$element.').addClass("'.$class.'");';
+	}
+
+	// --------------------------------------------------------------------
+
+	/**
+	 * Animate
+	 *
+	 * Outputs a jQuery animate event
+	 *
+	 * @param	string	$element
+	 * @param	array	$params
+	 * @param	string	$speed	'slow', 'normal', 'fast', or time in milliseconds
+	 * @param	string	$extra
+	 * @return	string
+	 */
+	protected function _animate($element = 'this', $params = array(), $speed = '', $extra = '')
+	{
+		$element = $this->_prep_element($element);
+		$speed = $this->_validate_speed($speed);
+
+		$animations = "\t\t\t";
+
+		foreach ($params as $param => $value)
+		{
+			$animations .= $param.": '".$value."', ";
+		}
+
+		$animations = substr($animations, 0, -2); // remove the last ", "
+
+		if ($speed !== '')
+		{
+			$speed = ', '.$speed;
+		}
+
+		if ($extra !== '')
+		{
+			$extra = ', '.$extra;
+		}
+
+		return "$({$element}).animate({\n$animations\n\t\t}".$speed.$extra.');';
+	}
+
+	// --------------------------------------------------------------------
+
+	/**
+	 * Fade In
+	 *
+	 * Outputs a jQuery hide event
+	 *
+	 * @param	string	- element
+	 * @param	string	- One of 'slow', 'normal', 'fast', or time in milliseconds
+	 * @param	string	- Javascript callback function
+	 * @return	string
+	 */
+	protected function _fadeIn($element = 'this', $speed = '', $callback = '')
+	{
+		$element = $this->_prep_element($element);
+		$speed = $this->_validate_speed($speed);
+
+		if ($callback !== '')
+		{
+			$callback = ", function(){\n{$callback}\n}";
+		}
+
+		return "$({$element}).fadeIn({$speed}{$callback});";
+	}
+
+	// --------------------------------------------------------------------
+
+	/**
+	 * Fade Out
+	 *
+	 * Outputs a jQuery hide event
+	 *
+	 * @param	string	- element
+	 * @param	string	- One of 'slow', 'normal', 'fast', or time in milliseconds
+	 * @param	string	- Javascript callback function
+	 * @return	string
+	 */
+	protected function _fadeOut($element = 'this', $speed = '', $callback = '')
+	{
+		$element = $this->_prep_element($element);
+		$speed = $this->_validate_speed($speed);
+
+		if ($callback !== '')
+		{
+			$callback = ", function(){\n{$callback}\n}";
+		}
+
+		return '$('.$element.').fadeOut('.$speed.$callback.');';
+	}
+
+	// --------------------------------------------------------------------
+
+	/**
+	 * Hide
+	 *
+	 * Outputs a jQuery hide action
+	 *
+	 * @param	string	- element
+	 * @param	string	- One of 'slow', 'normal', 'fast', or time in milliseconds
+	 * @param	string	- Javascript callback function
+	 * @return	string
+	 */
+	protected function _hide($element = 'this', $speed = '', $callback = '')
+	{
+		$element = $this->_prep_element($element);
+		$speed = $this->_validate_speed($speed);
+
+		if ($callback !== '')
+		{
+			$callback = ", function(){\n{$callback}\n}";
+		}
+
+		return "$({$element}).hide({$speed}{$callback});";
+	}
+
+	// --------------------------------------------------------------------
+
+	/**
+	 * Remove Class
+	 *
+	 * Outputs a jQuery remove class event
+	 *
+	 * @param	string	$element
+	 * @param	string	$class
+	 * @return	string
+	 */
+	protected function _removeClass($element = 'this', $class = '')
+	{
+		$element = $this->_prep_element($element);
+		return '$('.$element.').removeClass("'.$class.'");';
+	}
+
+	// --------------------------------------------------------------------
+
+	/**
+	 * Slide Up
+	 *
+	 * Outputs a jQuery slideUp event
+	 *
+	 * @param	string	- element
+	 * @param	string	- One of 'slow', 'normal', 'fast', or time in milliseconds
+	 * @param	string	- Javascript callback function
+	 * @return	string
+	 */
+	protected function _slideUp($element = 'this', $speed = '', $callback = '')
+	{
+		$element = $this->_prep_element($element);
+		$speed = $this->_validate_speed($speed);
+
+		if ($callback !== '')
+		{
+			$callback = ", function(){\n{$callback}\n}";
+		}
+
+		return '$('.$element.').slideUp('.$speed.$callback.');';
+	}
+
+	// --------------------------------------------------------------------
+
+	/**
+	 * Slide Down
+	 *
+	 * Outputs a jQuery slideDown event
+	 *
+	 * @param	string	- element
+	 * @param	string	- One of 'slow', 'normal', 'fast', or time in milliseconds
+	 * @param	string	- Javascript callback function
+	 * @return	string
+	 */
+	protected function _slideDown($element = 'this', $speed = '', $callback = '')
+	{
+		$element = $this->_prep_element($element);
+		$speed = $this->_validate_speed($speed);
+
+		if ($callback !== '')
+		{
+			$callback = ", function(){\n{$callback}\n}";
+		}
+
+		return '$('.$element.').slideDown('.$speed.$callback.');';
+	}
+
+	// --------------------------------------------------------------------
+
+	/**
+	 * Slide Toggle
+	 *
+	 * Outputs a jQuery slideToggle event
+	 *
+	 * @param	string	- element
+	 * @param	string	- One of 'slow', 'normal', 'fast', or time in milliseconds
+	 * @param	string	- Javascript callback function
+	 * @return	string
+	 */
+	protected function _slideToggle($element = 'this', $speed = '', $callback = '')
+	{
+		$element = $this->_prep_element($element);
+		$speed = $this->_validate_speed($speed);
+
+		if ($callback !== '')
+		{
+			$callback = ", function(){\n{$callback}\n}";
+		}
+
+		return '$('.$element.').slideToggle('.$speed.$callback.');';
+	}
+
+	// --------------------------------------------------------------------
+
+	/**
+	 * Toggle
+	 *
+	 * Outputs a jQuery toggle event
+	 *
+	 * @param	string	- element
+	 * @return	string
+	 */
+	protected function _toggle($element = 'this')
+	{
+		$element = $this->_prep_element($element);
+		return '$('.$element.').toggle();';
+	}
+
+	// --------------------------------------------------------------------
+
+	/**
+	 * Toggle Class
+	 *
+	 * Outputs a jQuery toggle class event
+	 *
+	 * @param	string	$element
+	 * @param	string	$class
+	 * @return	string
+	 */
+	protected function _toggleClass($element = 'this', $class = '')
+	{
+		$element = $this->_prep_element($element);
+		return '$('.$element.').toggleClass("'.$class.'");';
+	}
+
+	// --------------------------------------------------------------------
+
+	/**
+	 * Show
+	 *
+	 * Outputs a jQuery show event
+	 *
+	 * @param	string	- element
+	 * @param	string	- One of 'slow', 'normal', 'fast', or time in milliseconds
+	 * @param	string	- Javascript callback function
+	 * @return	string
+	 */
+	protected function _show($element = 'this', $speed = '', $callback = '')
+	{
+		$element = $this->_prep_element($element);
+		$speed = $this->_validate_speed($speed);
+
+		if ($callback !== '')
+		{
+			$callback = ", function(){\n{$callback}\n}";
+		}
+
+		return '$('.$element.').show('.$speed.$callback.');';
+	}
+
+	// --------------------------------------------------------------------
+
+	/**
+	 * Updater
+	 *
+	 * An Ajax call that populates the designated DOM node with
+	 * returned content
+	 *
+	 * @param	string	The element to attach the event to
+	 * @param	string	the controller to run the call against
+	 * @param	string	optional parameters
+	 * @return	string
+	 */
+
+	protected function _updater($container = 'this', $controller = '', $options = '')
+	{
+		$container = $this->_prep_element($container);
+		$controller = (strpos('://', $controller) === FALSE) ? $controller : $this->CI->config->site_url($controller);
+
+		// ajaxStart and ajaxStop are better choices here... but this is a stop gap
+		if ($this->CI->config->item('javascript_ajax_img') === '')
+		{
+			$loading_notifier = 'Loading...';
+		}
+		else
+		{
+			$loading_notifier = '<img src="'.$this->CI->config->slash_item('base_url').$this->CI->config->item('javascript_ajax_img').'" alt="Loading" />';
+		}
+
+		$updater = '$('.$container.").empty();\n" // anything that was in... get it out
+			."\t\t$(".$container.').prepend("'.$loading_notifier."\");\n"; // to replace with an image
+
+		$request_options = '';
+		if ($options !== '')
+		{
+			$request_options .= ', {'
+					.(is_array($options) ? "'".implode("', '", $options)."'" : "'".str_replace(':', "':'", $options)."'")
+					.'}';
+		}
+
+		return $updater."\t\t$($container).load('$controller'$request_options);";
+	}
+
+	// --------------------------------------------------------------------
+	// Pre-written handy stuff
+	// --------------------------------------------------------------------
+
+	/**
+	 * Zebra tables
+	 *
+	 * @param	string	$class
+	 * @param	string	$odd
+	 * @param	string	$hover
+	 * @return	string
+	 */
+	protected function _zebraTables($class = '', $odd = 'odd', $hover = '')
+	{
+		$class = ($class !== '') ? '.'.$class : '';
+		$zebra = "\t\$(\"table{$class} tbody tr:nth-child(even)\").addClass(\"{$odd}\");";
+
+		$this->jquery_code_for_compile[] = $zebra;
+
+		if ($hover !== '')
+		{
+			$hover = $this->hover("table{$class} tbody tr", "$(this).addClass('hover');", "$(this).removeClass('hover');");
+		}
+
+		return $zebra;
+	}
+
+	// --------------------------------------------------------------------
+	// Plugins
+	// --------------------------------------------------------------------
+
+	/**
+	 * Corner Plugin
+	 *
+	 * @link	http://www.malsup.com/jquery/corner/
+	 * @param	string	$element
+	 * @param	string	$corner_style
+	 * @return	string
+	 */
+	public function corner($element = '', $corner_style = '')
+	{
+		// may want to make this configurable down the road
+		$corner_location = '/plugins/jquery.corner.js';
+
+		if ($corner_style !== '')
+		{
+			$corner_style = '"'.$corner_style.'"';
+		}
+
+		return '$('.$this->_prep_element($element).').corner('.$corner_style.');';
+	}
+
+	// --------------------------------------------------------------------
+
+	/**
+	 * Modal window
+	 *
+	 * Load a thickbox modal window
+	 *
+	 * @param	string	$src
+	 * @param	bool	$relative
+	 * @return	void
+	 */
+	public function modal($src, $relative = FALSE)
+	{
+		$this->jquery_code_for_load[] = $this->external($src, $relative);
+	}
+
+	// --------------------------------------------------------------------
+
+	/**
+	 * Effect
+	 *
+	 * Load an Effect library
+	 *
+	 * @param	string	$src
+	 * @param	bool	$relative
+	 * @return	void
+	 */
+	public function effect($src, $relative = FALSE)
+	{
+		$this->jquery_code_for_load[] = $this->external($src, $relative);
+	}
+
+	// --------------------------------------------------------------------
+
+	/**
+	 * Plugin
+	 *
+	 * Load a plugin library
+	 *
+	 * @param	string	$src
+	 * @param	bool	$relative
+	 * @return	void
+	 */
+	public function plugin($src, $relative = FALSE)
+	{
+		$this->jquery_code_for_load[] = $this->external($src, $relative);
+	}
+
+	// --------------------------------------------------------------------
+
+	/**
+	 * UI
+	 *
+	 * Load a user interface library
+	 *
+	 * @param	string	$src
+	 * @param	bool	$relative
+	 * @return	void
+	 */
+	public function ui($src, $relative = FALSE)
+	{
+		$this->jquery_code_for_load[] = $this->external($src, $relative);
+	}
+
+	// --------------------------------------------------------------------
+
+	/**
+	 * Sortable
+	 *
+	 * Creates a jQuery sortable
+	 *
+	 * @param	string	$element
+	 * @param	array	$options
+	 * @return	string
+	 */
+	public function sortable($element, $options = array())
+	{
+		if (count($options) > 0)
+		{
+			$sort_options = array();
+			foreach ($options as $k=>$v)
+			{
+				$sort_options[] = "\n\t\t".$k.': '.$v;
+			}
+			$sort_options = implode(',', $sort_options);
+		}
+		else
+		{
+			$sort_options = '';
+		}
+
+		return '$('.$this->_prep_element($element).').sortable({'.$sort_options."\n\t});";
+	}
+
+	// --------------------------------------------------------------------
+
+	/**
+	 * Table Sorter Plugin
+	 *
+	 * @param	string	table name
+	 * @param	string	plugin location
+	 * @return	string
+	 */
+	public function tablesorter($table = '', $options = '')
+	{
+		$this->jquery_code_for_compile[] = "\t$(".$this->_prep_element($table).').tablesorter('.$options.");\n";
+	}
+
+	// --------------------------------------------------------------------
+	// Class functions
+	// --------------------------------------------------------------------
+
+	/**
+	 * Add Event
+	 *
+	 * Constructs the syntax for an event, and adds to into the array for compilation
+	 *
+	 * @param	string	The element to attach the event to
+	 * @param	string	The code to execute
+	 * @param	string	The event to pass
+	 * @return	string
+	 */
+	protected function _add_event($element, $js, $event)
+	{
+		if (is_array($js))
+		{
+			$js = implode("\n\t\t", $js);
+		}
+
+		$event = "\n\t$(".$this->_prep_element($element).').'.$event."(function(){\n\t\t{$js}\n\t});\n";
+		$this->jquery_code_for_compile[] = $event;
+		return $event;
+	}
+
+	// --------------------------------------------------------------------
+
+	/**
+	 * Compile
+	 *
+	 * As events are specified, they are stored in an array
+	 * This function compiles them all for output on a page
+	 *
+	 * @param	string	$view_var
+	 * @param	bool	$script_tags
+	 * @return	void
+	 */
+	protected function _compile($view_var = 'script_foot', $script_tags = TRUE)
+	{
+		// External references
+		$external_scripts = implode('', $this->jquery_code_for_load);
+		$this->CI->load->vars(array('library_src' => $external_scripts));
+
+		if (count($this->jquery_code_for_compile) === 0)
+		{
+			// no inline references, let's just return
+			return;
+		}
+
+		// Inline references
+		$script = '$(document).ready(function() {'."\n"
+			.implode('', $this->jquery_code_for_compile)
+			.'});';
+
+		$output = ($script_tags === FALSE) ? $script : $this->inline($script);
+
+		$this->CI->load->vars(array($view_var => $output));
+	}
+
+	// --------------------------------------------------------------------
+
+	/**
+	 * Clear Compile
+	 *
+	 * Clears the array of script events collected for output
+	 *
+	 * @return	void
+	 */
+	protected function _clear_compile()
+	{
+		$this->jquery_code_for_compile = array();
+	}
+
+	// --------------------------------------------------------------------
+
+	/**
+	 * Document Ready
+	 *
+	 * A wrapper for writing document.ready()
+	 *
+	 * @param	array	$js
+	 * @return	void
+	 */
+	protected function _document_ready($js)
+	{
+		is_array($js) OR $js = array($js);
+
+		foreach ($js as $script)
+		{
+			$this->jquery_code_for_compile[] = $script;
+		}
+	}
+
+	// --------------------------------------------------------------------
+
+	/**
+	 * Script Tag
+	 *
+	 * Outputs the script tag that loads the jquery.js file into an HTML document
+	 *
+	 * @param	string	$library_src
+	 * @param	bool	$relative
+	 * @return	string
+	 */
+	public function script($library_src = '', $relative = FALSE)
+	{
+		$library_src = $this->external($library_src, $relative);
+		$this->jquery_code_for_load[] = $library_src;
+		return $library_src;
+	}
+
+	// --------------------------------------------------------------------
+
+	/**
+	 * Prep Element
+	 *
+	 * Puts HTML element in quotes for use in jQuery code
+	 * unless the supplied element is the Javascript 'this'
+	 * object, in which case no quotes are added
+	 *
+	 * @param	string
+	 * @return	string
+	 */
+	protected function _prep_element($element)
+	{
+		if ($element !== 'this')
+		{
+			$element = '"'.$element.'"';
+		}
+
+		return $element;
+	}
+
+	// --------------------------------------------------------------------
+
+	/**
+	 * Validate Speed
+	 *
+	 * Ensures the speed parameter is valid for jQuery
+	 *
+	 * @param	string
+	 * @return	string
+	 */
+	protected function _validate_speed($speed)
+	{
+		if (in_array($speed, array('slow', 'normal', 'fast')))
+		{
+			return '"'.$speed.'"';
+		}
+		elseif (preg_match('/[^0-9]/', $speed))
+		{
+			return '';
+		}
+
+		return $speed;
+	}
+
+}

--- a/system/libraries/Pagination.php
+++ b/system/libraries/Pagination.php
@@ -358,6 +358,12 @@ class CI_Pagination {
 	 */
 	public function initialize(array $params = array())
 	{
+		if (isset($params['anchor_class']))
+		{
+			empty($params['anchor_class']) OR $params['attributes']['class'] = $params['anchor_class'];
+			unset($params['anchor_class']);
+		}
+
 		if (isset($params['attributes']) && is_array($params['attributes']))
 		{
 			$this->_parse_attributes($params['attributes']);

--- a/user_guide_src/source/installation/upgrade_320.rst
+++ b/user_guide_src/source/installation/upgrade_320.rst
@@ -187,9 +187,7 @@ CodeIgniter versions that have been removed in 3.2+:
 
 - 'sqlite' database driver (no longer shipped with PHP 5.4+; 'sqlite3' is still available)
 
-- The entire *Encrypt Library* (the newer :doc:`Encryption Library <../libraries/encryption>` is still available)
-- The entire *Javascript Library* (it was always experimental in the first place)
-- The entire *Smiley Helper* (an archived version is available on GitHub: `bcit-ci/ci3-smiley-helper <https://github.com/bcit-ci/ci3-smiley-helper>`_)
+- The entire *Encrypt Library* (the newer :doc:`Encryption Library <../libraries/encryption>` is still available; the old Encrypt library depends on MCrypt which was removed from PHP in 7.2)
 
 - The ``$img_path``, ``$img_url`` and ``$font_path`` parameters from
   :doc:`CAPCHA Helper <../helpers/captcha_helper>` function :php:func:`create_captcha()` (pass as array options instead).

--- a/user_guide_src/source/installation/upgrade_320.rst
+++ b/user_guide_src/source/installation/upgrade_320.rst
@@ -1,6 +1,11 @@
-#############################
-Upgrading from 3.1.x to 3.2.x
-#############################
+#######################################
+Upgrading from 3.1.x or 3.2-dev to 3.2+
+#######################################
+
+This guide covers upgrading to this maintenance fork, which is based on
+the unreleased CodeIgniter 3.2.0-dev. Many unnecessary breaking changes
+from 3.2.0-dev have been reverted to preserve backward compatibility.
+This is the same guide whether you are coming from 3.1.x or 3.2-dev.
 
 Before performing an update you should take your site offline by
 replacing the index.php file with a static one.
@@ -8,7 +13,16 @@ replacing the index.php file with a static one.
 Step 1: Update your CodeIgniter files
 =====================================
 
-Replace all files and directories in your *system/* directory.
+Install via Composer (recommended)::
+
+	composer require pocketarc/codeigniter
+
+Then update the ``$system_path`` in your ``index.php``::
+
+	$system_path = 'vendor/pocketarc/codeigniter/system';
+
+Alternatively, you can manually replace all files and directories in
+your *system/* directory.
 
 .. note:: If you have any custom developed files in these directories,
 	please make copies of them first.
@@ -16,13 +30,9 @@ Replace all files and directories in your *system/* directory.
 Step 2: Check your PHP version
 ==============================
 
-We recommend always running versions that are `currently supported
-<https://secure.php.net/supported-versions.php>`_, which right now is at least PHP 5.6.
-
-PHP 5.3.x versions are now officially not supported by CodeIgniter, and while 5.4.8+
-may be at least runnable, we strongly discourage you from using any PHP versions below
-the ones listed on the `PHP.net Supported Versions <https://secure.php.net/supported-versions.php>`_
-page.
+This fork supports PHP 5.4 through 8.5+. We recommend running a
+`currently supported <https://www.php.net/supported-versions.php>`_
+PHP version (8.4 or newer).
 
 Step 3: Calls to ``CI_Model::__construct()`` (optional cleanup)
 ===============================================================
@@ -169,26 +179,13 @@ Step 10: Remove usage of previously deprecated functionalities
 ==============================================================
 
 The following is a list of functionalities deprecated in previous
-CodeIgniter versions that have been removed in 3.2.0:
+CodeIgniter versions that have been removed in 3.2+:
 
 - ``$config['allow_get_array']`` (use ``$_GET = array();`` instead)
 - ``$config['standardize_newlines']``
 - ``$config['rewrite_short_tags']`` (no impact; irrelevant on PHP 5.4+)
 
 - 'sqlite' database driver (no longer shipped with PHP 5.4+; 'sqlite3' is still available)
-
-- ``CI_Input::is_cli_request()`` (use :php:func:`is_cli()` instead)
-- ``CI_Config::system_url()`` (encourages insecure practices)
-- ``CI_Form_validation::prep_for_form()`` (the *prep_for_form* rule)
-
-- ``standard_date()`` :doc:`Date Helper <../helpers/date_helper>` function (use ``date()`` instead)
-- ``nice_date()`` :doc:`Date Helper <../helpers/date_helper>` function (use ``DateTime::format()`` instead)
-- ``do_hash()`` :doc:`Security Helper <../helpers/security_helper>` function (use ``hash()`` instead)
-- ``br()`` :doc:`HTML Helper <../helpers/html_helper>` function (use ``str_repeat()`` with ``'<br />'`` instead)
-- ``nbs()`` :doc:`HTML Helper <../helpers/html_helper>` function (use ``str_repeat()`` with ``'&nbsp;'`` instead)
-- ``trim_slashes()`` :doc:`String Helper <../helpers/string_helper>` function (use ``trim()`` with ``'/'`` instead)
-- ``repeater()`` :doc:`String Helper <../helpers/string_helper>` function (use ``str_repeat()`` instead)
-- ``form_prep()`` :doc:`Form Helper <../helpers/form_helper>` function (use :php:func:`html_escape()` instead)
 
 - The entire *Encrypt Library* (the newer :doc:`Encryption Library <../libraries/encryption>` is still available)
 - The entire *Javascript Library* (it was always experimental in the first place)
@@ -238,14 +235,12 @@ The ``$curs_id`` property is also removed.
 If you were using those, you can create your own cursors via ``oci_new_cursor()``
 and the publicly accessible ``$conn_id``.
 
-Stop 14: Replace $config['log_file_extension'] with $config['log_filename'] in application/config/config.php
-============================================================================================================
+Step 14: Check log filename configuration in application/config/config.php
+==========================================================================
 
 You can now specify the full log filename via ``$config['log_filename']``.
 Add this configuration option to your **application/config/config.php**,
 if you haven't copied the new one over.
 
-The previously existing ``$config['log_file_extension']`` option has been
-removed and no longer works. However, its functionality is essentially
-integrated into the new ``$config['log_filename']``, since it includes the
-filename extension in itself.
+The ``$config['log_file_extension']`` option still works as a fallback,
+but ``$config['log_filename']`` takes precedence when set.

--- a/user_guide_src/source/installation/upgrade_320.rst
+++ b/user_guide_src/source/installation/upgrade_320.rst
@@ -191,10 +191,6 @@ CodeIgniter versions that have been removed in 3.2+:
 - The entire *Javascript Library* (it was always experimental in the first place)
 - The entire *Smiley Helper* (an archived version is available on GitHub: `bcit-ci/ci3-smiley-helper <https://github.com/bcit-ci/ci3-smiley-helper>`_)
 
-- The ``$_after`` parameter from :doc:`Database Forge <../database/forge>` method ``add_column()``.
-- The ``anchor_class`` option from :doc:`Pagination Library <../libraries/pagination>` (use ``class`` instead).
-- The ``unique`` and ``encrypt`` options from :doc:`String Helper <../helpers/string_helper>` function ``random_string()``.
-- The ``underscore`` and ``dash`` options from :doc:`URL Helper <../helpers/url_helper>`` function :php:func:`url_title()`.
 - The ``$img_path``, ``$img_url`` and ``$font_path`` parameters from
   :doc:`CAPCHA Helper <../helpers/captcha_helper>` function :php:func:`create_captcha()` (pass as array options instead).
 

--- a/user_guide_src/source/installation/upgrading.rst
+++ b/user_guide_src/source/installation/upgrading.rst
@@ -8,7 +8,7 @@ upgrading from.
 .. toctree::
 	:titlesonly:
 
-	Upgrading from 3.1.12+ to 3.2.x <upgrade_320>
+	Upgrading from 3.1.x or 3.2-dev to 3.2+ <upgrade_320>
 	Upgrading from 3.1.13 to 3.1.14 <upgrade_3114>
 	Upgrading from 3.1.12 to 3.1.13 <upgrade_3113>
 	Upgrading from 3.1.11 to 3.1.12 <upgrade_3112>


### PR DESCRIPTION
There were several removals in 3.2.0-dev that forced users to change working code for no real benefit. Each is a trivial wrapper or alias with zero maintenance burden. Restoring these reduces friction for anyone migrating from CI 3.1.x to this fork.

We've reverted several of these in the past, but I wanted to go through the upgrade guide and reduce as many breaking changes as I could. This PR gets rid of a bunch of breaking changes.