### PR TITLE
Update Edge user agent detection for legacy version and modern version detection fix

### DIFF
--- a/application/config/user_agents.php
+++ b/application/config/user_agents.php
@@ -61,7 +61,8 @@ $platforms = array(
 $browsers = array(
 	'OPR'			=> 'Opera',
 	'Flock'			=> 'Flock',
-	'Edge'			=> 'Edge',
+	'Edg' 			=> 'Edge',
+    'Edge' 			=> 'Edge Legacy',
 	'Chrome'		=> 'Chrome',
 	// Opera 10+ always reports Opera/9.80 and appends Version/<real version> to the user agent string
 	'Opera.*?Version'	=> 'Opera',


### PR DESCRIPTION
Update Edge user agent detection for legacy version and modern version that detect Edge with keyword 'Edg'