### PR TITLE
fix: Remove extra closing PHP tag from highlight_code() on PHP 8.3+ Fix #51.

### DIFF
--- a/system/helpers/text_helper.php
+++ b/system/helpers/text_helper.php
@@ -343,12 +343,12 @@ if ( ! function_exists('highlight_code'))
 		$str = preg_replace(
 			array(
 				'/<span style="color: #([A-Z0-9]+)">&lt;\?php(&nbsp;| )/i',
-				'/(<span style="color: #[A-Z0-9]+">.*?)\?&gt;<\/span>\n<\/span>\n<\/code>/is',
+				'/(<span style="color: #[A-Z0-9]+">.*?)\?&gt;<\/span>(\n<\/span>\n<\/code>|<\/code><\/pre>)/is',
 				'/<span style="color: #[A-Z0-9]+"\><\/span>/i'
 			),
 			array(
 				'<span style="color: #$1">',
-				"$1</span>\n</span>\n</code>",
+				'$1</span>$2',
 				''
 			),
 			$str

--- a/tests/codeigniter/helpers/text_helper_test.php
+++ b/tests/codeigniter/helpers/text_helper_test.php
@@ -104,7 +104,7 @@ class Text_helper_test extends CI_TestCase {
 		// PHP 8.3 changed highlight_string() output format
 		if (PHP_VERSION_ID >= 80300)
 		{
-			$expect = "<pre><code style=\"color: #000000\"><span style=\"color: #0000BB\">&lt;?php var_dump</span><span style=\"color: #007700\">(</span><span style=\"color: #0000BB\">\$this</span><span style=\"color: #007700\">); </span><span style=\"color: #0000BB\">?&gt; ?&gt;</span></code></pre>";
+			$expect = "<pre><code style=\"color: #000000\"><span style=\"color: #0000BB\">&lt;?php var_dump</span><span style=\"color: #007700\">(</span><span style=\"color: #0000BB\">\$this</span><span style=\"color: #007700\">); </span><span style=\"color: #0000BB\">?&gt; </span></code></pre>";
 		}
 		else
 		{
@@ -112,6 +112,18 @@ class Text_helper_test extends CI_TestCase {
 		}
 
 		$this->assertEquals($expect, highlight_code('<?php var_dump($this); ?>'));
+
+		// Test code without PHP tags (e.g. database queries in profiler)
+		if (PHP_VERSION_ID >= 80300)
+		{
+			$expect_query = "<pre><code style=\"color: #000000\"><span style=\"color: #0000BB\">SELECT </span><span style=\"color: #007700\">* </span><span style=\"color: #0000BB\">FROM users</span><span style=\"color: #007700\">; </span></code></pre>";
+		}
+		else
+		{
+			$expect_query = "<code><span style=\"color: #000000\">\n<span style=\"color: #0000BB\">SELECT&nbsp;</span><span style=\"color: #007700\">*&nbsp;</span><span style=\"color: #0000BB\">FROM&nbsp;users</span><span style=\"color: #007700\">;&nbsp;</span>\n</span>\n</code>";
+		}
+
+		$this->assertEquals($expect_query, highlight_code('SELECT * FROM users;'));
 	}
 
 	// ------------------------------------------------------------------------


### PR DESCRIPTION
PHP 8.3 changed the HTML returned by highlight_string(), so highlight_code() stopped removing the closing ?> it adds internally. This left a stray ?> at the end of queries in the profiler.

This updates the existing regex to handle both HTML formats, keeping compatibility with older PHP versions. It also fixes the test that expected the duplicate closing tag and adds coverage for a query without PHP tags.