### PR TITLE
fix: Add create_sid() to CI_SessionWrapper for PHP 8.6 compatibility

### DIFF
--- a/system/libraries/Session/PHP8SessionWrapper.php
+++ b/system/libraries/Session/PHP8SessionWrapper.php
@@ -97,4 +97,9 @@ class CI_SessionWrapper implements SessionHandlerInterface, SessionUpdateTimesta
 	{
 		return $this->driver->validateId($id);
 	}
+
+	public function create_sid(): string
+	{
+		return session_create_id();
+	}
 }


### PR DESCRIPTION
PHP 8.6 deprecates session save handlers that implement `SessionHandlerInterface` without a `create_sid()` method. The method will be required in PHP 9.0.

Add `create_sid(): string` to `CI_SessionWrapper`, delegating to `session_create_id()` to clear the deprecation. The method has been supported as an optional hook since PHP 7.1 and is a no-op on earlier versions, adding it shouldn't change behaviour on PHP 8.0 - 8.5, it just clears the 8.6 deprecation ahead of the 9.0 requirement.

Verified on PHP 8.0 - 8.5 and 8.6 beta 2:

- Starting new sessions and resuming existing ones
- `session_regenerate_id()` and `session_regenerate_id(true)`
- Explicit `session_create_id()` calls
- No warnings or deprecations during these checks